### PR TITLE
update setup-r workflow version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          install-r: false
       - name: Query dependencies
         run: |
           Rscript \


### PR DESCRIPTION
This updates r-lib/actions/setup-r to use v2 instead of the defunct (and no longer re-routed) "master"
